### PR TITLE
[Smartswitch] Host container differentiation for sensor commands

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -812,7 +812,6 @@ class ModuleBase(device_base.DeviceBase):
             container_command = ['docker', 'exec', 'pmon']
             restart_command = ['service', 'sensord', 'restart']
 
-
             if self.is_host:
                 file_exists_command = container_command + file_exists_command
                 copy_command = container_command + copy_command


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Differentiate commands being executed in host and container seperately for some smartswitch specific functions,
sensord commands can only be executed inside hte pmon docker container, so these commands need to differentiate between host and container execution

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This is done because these functions are called from inside the pmon docker during chassis command execution and from the host directly during reboot command execution

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
tests/module_base_test.py::TestModuleBase::test_module_base PASSED       [  2%]
tests/module_base_test.py::TestModuleBase::test_is_container_detection PASSED [  2%]
tests/module_base_test.py::TestModuleBase::test_sensors PASSED           [  2%]
tests/module_base_test.py::TestModuleBase::test_pci_entry_state_db PASSED [  2%]
tests/module_base_test.py::TestModuleBase::test_file_operation_lock PASSED [  2%]
tests/module_base_test.py::TestModuleBase::test_pci_operation_lock PASSED [  2%]
tests/module_base_test.py::TestModuleBase::test_sensord_operation_lock PASSED [  3%]
tests/module_base_test.py::TestModuleBase::test_handle_pci_removal PASSED [  3%]
tests/module_base_test.py::TestModuleBase::test_handle_pci_rescan PASSED [  3%]
tests/module_base_test.py::TestModuleBase::test_handle_sensor_removal PASSED [  3%]
tests/module_base_test.py::TestModuleBase::test_handle_sensor_addition PASSED [  3%]
tests/module_base_test.py::TestModuleBase::test_module_pre_shutdown PASSED [  3%]
tests/module_base_test.py::TestModuleBase::test_module_post_startup PASSED [  3%]
```
Manual test with:
`reboot -d DPU0`
and `config chassis modules startup DPU0`
#### Additional Information (Optional)

