### PR TITLE
[Smartswitch] Fix device base path for platform file

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -500,7 +500,7 @@ class ModuleBase(device_base.DeviceBase):
         if self.is_host:
             from sonic_py_common import device_info
             platform = device_info.get_platform()
-            platform_json_path = f"/usr/share/sonic/{platform}/platform.json"
+            platform_json_path = f"/usr/share/sonic/device/{platform}/platform.json"
         else:
             platform_json_path = "/usr/share/sonic/platform/platform.json"
 

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -561,7 +561,7 @@ class TestModuleBase:
              patch("os.path.exists", return_value=True) as pexists, \
              patch("builtins.open", return_value=MockFile("{}")):
             self.module._load_transition_timeouts()
-            pexists.assert_called_with("/usr/share/sonic/x86_64-dellemc_z9332f_d1508-r0/platform.json")
+            pexists.assert_called_with("/usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0/platform.json")
         ModuleBase._TRANSITION_TIMEOUTS_CACHE = None
 
     def test_load_transition_timeouts_platform_path_container(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The timeout configuration is obtained from the platform.json in case of smartswitch platforms. The path used currently is wrong, and therefore default values are used instead of the expected values, causing issues with

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This path is used to obtain timeouts when we execute `config chassis modules startup/shutdown` commands, causing incorrect timeout configurations

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Execute `config chassis modules shutdown/startup` commands

#### Additional Information (Optional)

